### PR TITLE
Add mmp_phys to uberblock

### DIFF
--- a/cmd/zdb/zdb.c
+++ b/cmd/zdb/zdb.c
@@ -2102,6 +2102,15 @@ dump_uberblock(uberblock_t *ub, const char *header, const char *footer)
 	(void) printf("\tguid_sum = %llu\n", (u_longlong_t)ub->ub_guid_sum);
 	(void) printf("\ttimestamp = %llu UTC = %s",
 	    (u_longlong_t)ub->ub_timestamp, asctime(localtime(&timestamp)));
+	(void) printf("\tmmp_magic = %016llx\n", (u_longlong_t)ub->ub_mmp.mmp_magic);
+	(void) printf("\tmmp_pool_guid = %llu\n", (u_longlong_t)ub->ub_mmp.mmp_pool_guid);
+	(void) printf("\tmmp_open_id = %llu\n", (u_longlong_t)ub->ub_mmp.mmp_open_id);
+	(void) printf("\tmmp_seq = %llu\n", (u_longlong_t)ub->ub_mmp.mmp_seq);
+	(void) printf("\tmmp_interval = %llu\n", (u_longlong_t)ub->ub_mmp.mmp_interval);
+	(void) printf("\tmmp_delay = %llu\n", (u_longlong_t)ub->ub_mmp.mmp_delay);
+	(void) printf("\tmmp_nodename = %s\n", ub->ub_mmp.mmp_nodename);
+	(void) printf("\tmmp_op = %llu\n", (u_longlong_t)ub->ub_mmp.mmp_op);
+	(void) printf("\tmmp_first_txg = %llu\n", (u_longlong_t)ub->ub_mmp.mmp_first_txg);
 	if (dump_opt['u'] >= 3) {
 		char blkbuf[BP_SPRINTF_LEN];
 		snprintf_blkptr(blkbuf, sizeof (blkbuf), &ub->ub_rootbp);

--- a/include/sys/Makefile.am
+++ b/include/sys/Makefile.am
@@ -34,6 +34,7 @@ COMMON_H = \
 	$(top_srcdir)/include/sys/efi_partition.h \
 	$(top_srcdir)/include/sys/metaslab.h \
 	$(top_srcdir)/include/sys/metaslab_impl.h \
+	$(top_srcdir)/include/sys/mmp.h \
 	$(top_srcdir)/include/sys/mntent.h \
 	$(top_srcdir)/include/sys/multilist.h \
 	$(top_srcdir)/include/sys/nvpair.h \

--- a/include/sys/mmp.h
+++ b/include/sys/mmp.h
@@ -1,0 +1,45 @@
+/*
+ * XXX missing license and copyright stuff
+*/
+
+#ifndef _SYS_MMP_H
+#define	_SYS_MMP_H
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+#define	MMP_MAGIC		0xa11cea11		/* all-see-all */
+#define	MMP_CLEAN_ID		0xc1e9b10c		/* clea(r/n)-block */
+
+/*
+ * MMP blocks may be written to disk by different processes.  Knowing which
+ * process wrote a given block may help the sysadmin determine the order of
+ * events, and which txg to roll back to, in the event of simultaneous imports
+ * of a pool.
+ */
+typedef enum mmp_op {
+	MO_TXG_SYNC,
+	MO_INTERVAL_WRITE,
+	MO_IMPORT_ATTEMPT,
+} mmp_op_t;
+
+struct mmp_phys {
+	uint64_t  mmp_magic;		/* MMP_MAGIC if valid */
+	uint64_t  mmp_pool_guid;	
+	uint64_t  mmp_open_id;		/* ID associated with an import */
+	uint64_t  mmp_seq;		/* MMP blocks written since open */
+	uint32_t  mmp_interval;		/* Max time to next mmp write period between mmp write */
+	uint32_t  mmp_delay;		/* Approx. delay at last update */
+	char	  mmp_nodename[64];	/* Node which wrote this block */
+	mmp_op_t  mmp_op;		/* Reason this block was written */
+	uint64_t  mmp_first_txg;	/* First txg written by this node */
+	/* zio_block_tail_t	mmp_zbt; */
+};
+typedef struct mmp_phys mmp_phys_t;
+
+#ifdef	__cplusplus
+}
+#endif
+
+#endif	/* _SYS_MMP_H */

--- a/include/sys/spa.h
+++ b/include/sys/spa.h
@@ -928,6 +928,11 @@ extern boolean_t spa_debug_enabled(spa_t *spa);
 
 extern int spa_mode_global;			/* mode, e.g. FREAD | FWRITE */
 
+/* mmp sequence counter */
+extern void spa_mmp_seq_bump(spa_t *spa);
+extern void spa_mmp_init(spa_t *spa);
+
+
 #ifdef	__cplusplus
 }
 #endif

--- a/include/sys/spa_impl.h
+++ b/include/sys/spa_impl.h
@@ -253,6 +253,8 @@ struct spa {
 	uint64_t	spa_errata;		/* errata issues detected */
 	spa_stats_t	spa_stats;		/* assorted spa statistics */
 	hrtime_t	spa_ccw_fail_time;	/* Conf cache write fail time */
+	kmutex_t	spa_mmp_lock;		/* protects spa_mmp */
+	mmp_phys_t	spa_mmp;		/* MMP info for syncs */
 
 	/*
 	 * spa_refcount & spa_config_lock must be the last elements

--- a/include/sys/uberblock.h
+++ b/include/sys/uberblock.h
@@ -32,6 +32,7 @@
 #include <sys/spa.h>
 #include <sys/vdev.h>
 #include <sys/zio.h>
+#include <sys/mmp.h>
 
 #ifdef	__cplusplus
 extern "C" {
@@ -41,6 +42,7 @@ typedef struct uberblock uberblock_t;
 
 extern int uberblock_verify(uberblock_t *);
 extern boolean_t uberblock_update(uberblock_t *, vdev_t *, uint64_t);
+extern void uberblock_mmp_update(uberblock_t *ub, const mmp_phys_t *mmp, mmp_op_t op);
 
 #ifdef	__cplusplus
 }

--- a/include/sys/uberblock_impl.h
+++ b/include/sys/uberblock_impl.h
@@ -54,6 +54,8 @@ struct uberblock {
 
 	/* highest SPA_VERSION supported by software that wrote this txg */
 	uint64_t	ub_software_version;
+	mmp_phys_t	ub_mmp;		/* Multi-Modifier Protection	*/
+
 };
 
 #ifdef	__cplusplus

--- a/module/zfs/spa_misc.c
+++ b/module/zfs/spa_misc.c
@@ -561,6 +561,7 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 	mutex_init(&spa->spa_suspend_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_vdev_top_lock, NULL, MUTEX_DEFAULT, NULL);
 	mutex_init(&spa->spa_feat_stats_lock, NULL, MUTEX_DEFAULT, NULL);
+	mutex_init(&spa->spa_mmp_lock, NULL, MUTEX_DEFAULT, NULL);
 
 	cv_init(&spa->spa_async_cv, NULL, CV_DEFAULT, NULL);
 	cv_init(&spa->spa_evicting_os_cv, NULL, CV_DEFAULT, NULL);
@@ -627,6 +628,8 @@ spa_add(const char *name, nvlist_t *config, const char *altroot)
 
 	spa->spa_min_ashift = INT_MAX;
 	spa->spa_max_ashift = 0;
+
+	spa_mmp_init(spa);
 
 	/*
 	 * As a pool is being created, treat all features as disabled by
@@ -702,6 +705,7 @@ spa_remove(spa_t *spa)
 	mutex_destroy(&spa->spa_suspend_lock);
 	mutex_destroy(&spa->spa_vdev_top_lock);
 	mutex_destroy(&spa->spa_feat_stats_lock);
+	mutex_destroy(&spa->spa_mmp_lock);
 
 	kmem_free(spa, sizeof (spa_t));
 }

--- a/module/zfs/uberblock.c
+++ b/module/zfs/uberblock.c
@@ -40,6 +40,16 @@ uberblock_verify(uberblock_t *ub)
 }
 
 /*
+ * Update the mmp part of the uberblock
+ */
+void
+uberblock_mmp_update(uberblock_t *ub, const mmp_phys_t *mmp, mmp_op_t op)
+{
+	memcpy(&ub->ub_mmp, mmp, sizeof(*mmp));
+	ub->ub_mmp.mmp_op = op;
+}
+
+/*
  * Update the uberblock and return TRUE if anything changed in this
  * transaction group.
  */

--- a/module/zfs/vdev_label.c
+++ b/module/zfs/vdev_label.c
@@ -1228,6 +1228,8 @@ retry:
 
 	ASSERT(txg <= spa->spa_final_txg);
 
+	uberblock_mmp_update(ub, &spa->spa_mmp, MO_TXG_SYNC);
+
 	/*
 	 * Flush the write cache of every disk that's been written to
 	 * in this transaction group.  This ensures that all blocks


### PR DESCRIPTION
Define a structure for detecting multiple simultaneous imports of a
pool.  Add that structure to the end of the uberblock.

Initialize the structure when pools are imported or created, and
increment its' sequence count, mmp_seq, with each sync of a pool.

Extend zdb so that zdb -l <vdev> -u prints the mmp fields.
